### PR TITLE
Add subdir to PkgSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install juliapkg
 - `require_julia(version, target=None)` declares that you require the given version of
   Julia. The `version` is a Julia compat specifier, so `1.5` matches any `1.*.*` version at
   least `1.5`.
-- `add(pkg, uuid, dev=False, version=None, path=None, url=None, rev=None, target=None)`
+- `add(pkg, uuid, dev=False, version=None, path=None, subdir=None, url=None, rev=None, target=None)`
   adds a required package. Its name and UUID are required.
 - `rm(pkg, target=None)` remove a package.
 

--- a/src/juliapkg/deps.py
+++ b/src/juliapkg/deps.py
@@ -36,12 +36,13 @@ def save_meta(meta):
 ### RESOLVE
 
 class PkgSpec:
-    def __init__(self, name, uuid, dev=False, version=None, path=None, url=None, rev=None):
+    def __init__(self, name, uuid, dev=False, version=None, path=None, subdir=None, url=None, rev=None):
         self.name = name
         self.uuid = uuid
         self.dev = dev
         self.version = version
         self.path = path
+        self.subdir = subdir
         self.url = url
         self.rev = rev
 
@@ -49,6 +50,8 @@ class PkgSpec:
         args = ['name="{}"'.format(self.name), 'uuid="{}"'.format(self.uuid)]
         if self.path is not None:
             args.append('path=raw"{}"'.format(self.path))
+        if self.subdir is not None:
+            args.append('subdir="{}"'.format(self.subdir))
         if self.url is not None:
             args.append('url=raw"{}"'.format(self.url))
         if self.rev is not None:
@@ -62,6 +65,7 @@ class PkgSpec:
             "dev": self.dev,
             "version": str(self.version),
             "path": self.path,
+            "subdir": self.subdir,
             "url": self.url,
             "rev": self.rev,
         }
@@ -76,6 +80,8 @@ class PkgSpec:
             ans['version'] = str(self.version)
         if self.path is not None:
             ans['path'] = self.path
+        if self.subdir is not None:
+            ans['subdir'] = self.subdir
         if self.url is not None:
             ans['url'] = self.url
         if self.rev is not None:
@@ -192,6 +198,7 @@ def required_packages():
         kw = {'name': name}
         merge_unique(kw, kfvs, 'uuid')
         merge_unique(kw, kfvs, 'path')
+        merge_unique(kw, kfvs, 'subdir')
         merge_unique(kw, kfvs, 'url')
         merge_unique(kw, kfvs, 'rev')
         merge_compat(kw, kfvs, 'version')


### PR DESCRIPTION
Export Julia's PackageSpec `subdir` option, which allows the user to specify a folder inside the repository where the Julia package is located. See: https://pkgdocs.julialang.org/v1/api/#Pkg.PackageSpec
