### PR TITLE
Use sys.prefix to determine if inside a virtualenv

### DIFF
--- a/src/juliapkg/state.py
+++ b/src/juliapkg/state.py
@@ -58,7 +58,7 @@ def reset_state():
             raise Exception(f'{project_key} must be an absolute path')
         STATE['project'] = project
     else:
-        vprefix = os.getenv('VIRTUAL_ENV')
+        vprefix = sys.prefix if sys.prefix != sys.base_prefix else None
         cprefix = os.getenv('CONDA_PREFIX')
         if cprefix and vprefix:
             raise Exception('You are using both a virtual and conda environment, cannot figure out which to use!')


### PR DESCRIPTION
Fixes #30

> Just need to double check that the test doesn't pass in a Conda environment.

When in a conda env, `sys.prefix` is the same as `sys.base_prefix`, so we still need the extra logic for conda.