### PR TITLE
Set required python version to >= 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Julia version manager and package manager"
 authors = [{ name = "Christopher Doris" }]
 dependencies = ["semver~=3.0"]
 readme = "README.md"
-requires-python = "~=3.8"
+requires-python = ">=3.8"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Fixes #40 

This seems to be working for me, so I thought I'd share it. Without this I can't install `juliacall` using poetry for python versions other than 3.8. 