### PR TITLE
Throw exception when `julia --version` fails.

### DIFF
--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -197,6 +197,8 @@ def ju_find_julia_noinstall(compat=None):
         for exe, _ in versions:
             ver = julia_version(exe)
             if ver is None:
-                raise Exception(f"Failed to execute {exe} --version")
+                raise Exception(
+                    f"{exe} (installed by juliaup) is not a valid Julia executable"
+                )
             if compat is None or ver in compat:
                 return (exe, ver)

--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -196,5 +196,7 @@ def ju_find_julia_noinstall(compat=None):
         versions.sort(key=lambda x: x[1], reverse=True)
         for exe, _ in versions:
             ver = julia_version(exe)
+            if ver is None:
+                raise Exception(f'WARNING: Failed to execute {exe} --version')
             if compat is None or ver in compat:
                 return (exe, ver)

--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -197,6 +197,6 @@ def ju_find_julia_noinstall(compat=None):
         for exe, _ in versions:
             ver = julia_version(exe)
             if ver is None:
-                raise Exception(f'WARNING: Failed to execute {exe} --version')
+                raise Exception(f"Failed to execute {exe} --version")
             if compat is None or ver in compat:
                 return (exe, ver)


### PR DESCRIPTION
Recently, I managed to corrupt my julia installation so that `julia --version` returned
```
% julia --version
ERROR: Unable to load dependent library /home/user/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/bin/../lib/julia/libopenlibm.so
Message:/home/user/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/bin/../lib/julia/libopenlibm.so: cannot enable executable stack as shared object requires: Invalid argument
```

This is of course an edge case, but did lead to the following confusing stacktrace, so an exception has been added in case the command fails.

(Confusing) Stacktrace:
```
[juliapkg] Found dependencies: /home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/juliapkg.json
[juliapkg] Found dependencies: /home/user/Documents/Work/CERN/hets/juliapkg.json
[juliapkg] Found dependencies: /home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliacall/juliapkg.json
[juliapkg] Locating Julia ~1.11
Traceback (most recent call last):
  File "/home/user/Documents/Work/CERN/hets/./hets.py", line 94, in <module>
    from hets.solver import get_latest_solver_dir
  File "/home/user/Documents/Work/CERN/hets/hets/solver/__init__.py", line 1, in <module>
    from .problem import HETSProblem
  File "/home/user/Documents/Work/CERN/hets/hets/solver/problem.py", line 19, in <module>
    torch = import_torch()
            ^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/hets/support/__init__.py", line 36, in import_torch
    import_julia()
  File "/home/user/Documents/Work/CERN/hets/hets/support/__init__.py", line 27, in import_julia
    import juliacall
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliacall/__init__.py", line 287, in <module>
    init()
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliacall/__init__.py", line 159, in init
    CONFIG['exepath'] = exepath = juliapkg.executable()
                                  ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/deps.py", line 381, in executable
    resolve()
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/deps.py", line 307, in resolve
    exe, ver = find_julia(
               ^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/find_julia.py", line 75, in find_julia
    ans = ju_find_julia(ju_compat, install=install)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/find_julia.py", line 149, in ju_find_julia
    ans = ju_find_julia_noinstall(compat)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/find_julia.py", line 199, in ju_find_julia_noinstall
    if compat is None or ver in compat:
                         ^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/compat.py", line 31, in __contains__
    return any(v in clause for clause in self.clauses)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/compat.py", line 31, in <genexpr>
    return any(v in clause for clause in self.clauses)
               ^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/compat.py", line 169, in __contains__
    return self.lo <= v < self.hi
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<=' not supported between instances of 'Version' and 'NoneType'
```

Instead, the error message is now:
```
[juliapkg] Locating Julia ~1.11
Traceback (most recent call last):
  File "/home/user/Documents/Work/CERN/hets/./hets.py", line 94, in <module>
    from hets.solver import get_latest_solver_dir
  File "/home/user/Documents/Work/CERN/hets/hets/solver/__init__.py", line 1, in <module>
    from .problem import HETSProblem
  File "/home/user/Documents/Work/CERN/hets/hets/solver/problem.py", line 19, in <module>
    torch = import_torch()
            ^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/hets/support/__init__.py", line 36, in import_torch
    import_julia()
  File "/home/user/Documents/Work/CERN/hets/hets/support/__init__.py", line 27, in import_julia
    import juliacall
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliacall/__init__.py", line 287, in <module>
    init()
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliacall/__init__.py", line 159, in init
    CONFIG['exepath'] = exepath = juliapkg.executable()
                                  ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/deps.py", line 381, in executable
    resolve()
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/deps.py", line 307, in resolve
    exe, ver = find_julia(
               ^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/find_julia.py", line 75, in find_julia
    ans = ju_find_julia(ju_compat, install=install)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/find_julia.py", line 149, in ju_find_julia
    ans = ju_find_julia_noinstall(compat)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Work/CERN/hets/venv/lib/python3.12/site-packages/juliapkg/find_julia.py", line 200, in ju_find_julia_noinstall
    raise Exception(f'WARNING: Failed to execute {exe} --version')
Exception: WARNING: Failed to execute /home/user/.julia/juliaup/julia-1.11.3+0.x64.linux.gnu/bin/julia --version
```