### PR TITLE
add openssl compat handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Add special handling of `<=python` version for OpenSSL compatibility between Julia and Python.
+
 ## v0.1.16 (2025-02-18)
 * Adds file-locking to protect multiple concurrent resolves.
 

--- a/src/juliapkg/deps.py
+++ b/src/juliapkg/deps.py
@@ -193,10 +193,13 @@ def deps_files():
     )
 
 
-def openssl_compat():
-    import ssl
+def openssl_compat(version=None):
+    if version is None:
+        import ssl
 
-    major, minor, patch, *_ = ssl.OPENSSL_VERSION_INFO
+        version = ssl.OPENSSL_VERSION_INFO
+
+    major, minor, patch = version[:3]
     if major >= 3:
         return f"{major} - {major}.{minor}"
     else:

--- a/test/test_internals.py
+++ b/test/test_internals.py
@@ -1,0 +1,10 @@
+import juliapkg
+
+
+def test_openssl_compat():
+    assert juliapkg.deps.openssl_compat((1, 2, 3)) == "1.2 - 1.2.3"
+    assert juliapkg.deps.openssl_compat((2, 3, 4)) == "2.3 - 2.3.4"
+    assert juliapkg.deps.openssl_compat((3, 0, 0)) == "3 - 3.0"
+    assert juliapkg.deps.openssl_compat((3, 1, 0)) == "3 - 3.1"
+    assert juliapkg.deps.openssl_compat((3, 1, 2)) == "3 - 3.1"
+    assert isinstance(juliapkg.deps.openssl_compat(), str)


### PR DESCRIPTION
With this PR, if you specify `version = "<=python"` on `OpenSSL_jll` then the version installed will be compatible with the version of OpenSSL shipped with Python. We do the same thing over in CondaPkg.jl.

You can test this out by installing `juliapkg` from this branch:
```sh
pip install juliapkg@git+https://github.com/JuliaPy/pyjuliapkg@openssl-compat
```
and then do this in Python before anything else you run
```python
import juliapkg
juliapkg.add("OpenSSL_jll", uuid="458c3c95-2e84-50aa-8efc-19380b2a3a95", version="<=python")
juliapkg.resolve()
```

If this PR is merged then we'll add the `<=python` compat to juliacall so this happens transparently in the future.