### PR TITLE
avoid multiple STATE instances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.5
+  rev: v0.12.1
   hooks:
     # Run the formatter.
     - id: ruff-format

--- a/src/juliapkg/state.py
+++ b/src/juliapkg/state.py
@@ -1,7 +1,8 @@
 import os
 import sys
+from typing import Final
 
-STATE = {}
+STATE: Final = {}
 
 
 def get_config(name, default=None):
@@ -39,8 +40,7 @@ def get_config_bool(name, default=False):
 
 
 def reset_state():
-    global STATE
-    STATE = {}
+    STATE.clear()
 
     # Are we running a dev version?
     STATE["dev"] = os.path.exists(


### PR DESCRIPTION
Since state.STATE is also imported from deps.py, when reset_state() was resetting it, deps.STATE & state.STATE were referencing to different dict instances
Added [Final qualifer](https://peps.python.org/pep-0591/) to hint the risk.