### PR TITLE
explicitly set project are now considered "shared"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+* If the project is explicitly specified, it is considered "shared" and existing
+  dependencies are never removed.
+
 ## v0.1.19 (2025-09-17)
 * Add the CLI.
 * Improve some error messages.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ following strategies in order:
 
 More strategies may be added in a future release.
 
+If the project is explicitly specified (with `-X juliapkg-project` or
+`PYTHON_JULIAPKG_PROJECT`) then it is considered "shared" and dependencies will only
+ever be added, not removed.
+
 ### Adding Julia dependencies to Python packages
 
 JuliaPkg looks for `juliapkg.json` files in many locations, namely:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,11 @@ name = "juliapkg"
 version = "0.1.19"
 description = "Julia version manager and package manager"
 authors = [{ name = "Christopher Doris" }]
-dependencies = ["semver >=3.0,<4.0", "filelock >=3.16,<4.0"]
+dependencies = [
+    "semver >=3.0,<4.0",
+    "filelock >=3.16,<4.0",
+    "tomlkit >=0.13.3,<0.14",
+]
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [

--- a/src/juliapkg/deps.py
+++ b/src/juliapkg/deps.py
@@ -7,6 +7,7 @@ import sys
 from subprocess import run
 from typing import Union
 
+import tomlkit
 from filelock import FileLock
 
 from .compat import Compat, Version
@@ -470,25 +471,51 @@ def resolve(force=False, dry_run=False, update=False):
         )
         log(f"Using Julia {ver} at {exe}")
         # set up the project
-        log(f"Using Julia project at {project}")
+        shared = STATE["project_is_shared"]
+        log(f"Using {'shared ' if shared else ''}Julia project at {project}")
         if not STATE["offline"]:
-            # write a Project.toml specifying UUIDs and compatibility of required
-            # packages
-            projtoml = []
-            projtoml.append("[deps]")
-            projtoml.extend(f'{pkg.name} = "{pkg.uuid}"' for pkg in pkgs)
-            projtoml.append("[compat]")
-            projtoml.extend(
-                f'{pkg.name} = "{pkg.version}"' for pkg in pkgs if pkg.version
+            # load the existing Project.toml if the project is shared
+            projtoml = None
+            foundprojtoml = False
+            if shared:
+                for fn in ["JuliaProject.toml", "Project.toml"]:
+                    projfile = os.path.join(project, fn)
+                    if os.path.isfile(projfile):
+                        with open(projfile) as fp:
+                            projtoml = tomlkit.load(fp)
+                            foundprojtoml = True
+                        break
+            # otherwise we start with a blank document
+            if not foundprojtoml:
+                projfile = os.path.join(project, "Project.toml")
+                projtoml = tomlkit.document()
+            # add/update the deps table
+            projdeps = projtoml.setdefault("deps", tomlkit.table())
+            for pkg in pkgs:
+                projdeps[pkg.name] = pkg.uuid
+            # add/update the compat table
+            projcompat = projtoml.setdefault("compat", tomlkit.table())
+            for pkg in pkgs:
+                if pkg.version:
+                    projcompat[pkg.name] = pkg.version
+                else:
+                    projcompat.pop(pkg.name, None)
+            # write it out
+            projtomlstr = tomlkit.dumps(projtoml)
+            log_script(
+                projtomlstr.splitlines(),
+                ("Updating" if foundprojtoml else "Writing")
+                + " "
+                + os.path.basename(projfile)
+                + ":",
             )
-            log_script(projtoml, "Writing Project.toml:")
-            with open(os.path.join(project, "Project.toml"), "wt") as fp:
-                for line in projtoml:
-                    print(line, file=fp)
+            with open(projfile, "wt") as fp:
+                fp.write(projtomlstr)
             # remove Manifest.toml
-            manifest_path = os.path.join(project, "Manifest.toml")
-            if os.path.exists(manifest_path):
-                os.remove(manifest_path)
+            if not shared:
+                manifest_path = os.path.join(project, "Manifest.toml")
+                if os.path.exists(manifest_path):
+                    os.remove(manifest_path)
             # install the packages
             dev_pkgs = [pkg for pkg in pkgs if pkg.dev]
             add_pkgs = [pkg for pkg in pkgs if not pkg.dev]

--- a/src/juliapkg/state.py
+++ b/src/juliapkg/state.py
@@ -66,6 +66,7 @@ def reset_state():
         if not os.path.isabs(project):
             raise Exception(f"{project_key} must be an absolute path")
         STATE["project"] = project
+        STATE["project_is_shared"] = True
     else:
         if sys.prefix != sys.base_prefix:
             # definitely in a virtual environment
@@ -81,6 +82,7 @@ def reset_state():
         else:
             # in a virtual or conda environment
             STATE["project"] = os.path.abspath(os.path.join(prefix, "julia_env"))
+        STATE["project_is_shared"] = False
 
     # meta file
     STATE["prefix"] = os.path.join(STATE["project"], "pyjuliapkg")


### PR DESCRIPTION
From the README:

> If the project is explicitly specified (with `-X juliapkg-project` or `PYTHON_JULIAPKG_PROJECT`) then it is considered "shared" and dependencies will only ever be added, not removed.
