### PR TITLE
uuid is now optional (discovered automatically)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* The UUID is no longer required when adding a dependency.
+
 ## v0.1.19 (2025-09-17)
 * Add the CLI.
 * Improve some error messages.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ pip install juliapkg
 - `require_julia(version, target=None)` declares that you require the given version of
   Julia. The `version` is a Julia compat specifier, so `1.5` matches any `1.*.*` version at
   least `1.5`.
-- `add(pkg, uuid, dev=False, version=None, path=None, subdir=None, url=None, rev=None, target=None)`
-  adds a required package. Its name and UUID are required.
+- `add(pkg, uuid=None, dev=False, version=None, path=None, subdir=None, url=None, rev=None, target=None)`
+  adds a required package.
 - `rm(pkg, target=None)` remove a package.
 
 Note that these functions edit `juliapkg.json` but do not actually install anything until
@@ -60,7 +60,7 @@ Julia v1.*.* and the Example package v0.5.*:
 You can also use the CLI, some examples:
 ```sh
 python -m juliapkg --help
-python -m juliapkg add Example --uuid=7876af07-990d-54b4-ab0e-23690620f79a --version=0.5
+python -m juliapkg add Example --version=0.5
 python -m juliapkg resolve
 python -m juliapkg status
 python -m juliapkg run -E 'using Example; Example.hello("world")'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "semver >=3.0,<4.0",
     "filelock >=3.16,<4.0",
     "tomlkit >=0.13.3,<0.14",
+    "tomli >=2.0,<3.0",
 ]
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/juliapkg/cli.py
+++ b/src/juliapkg/cli.py
@@ -54,7 +54,7 @@ else:
 
     @cli.command(name="add")
     @click.argument("package")
-    @click.option("--uuid", required=True, help="UUID of the package")
+    @click.option("--uuid", help="UUID of the package")
     @click.option("--version", help="Version constraint")
     @click.option("--dev", is_flag=True, help="Add as development dependency")
     @click.option("--path", help="Local path to package")

--- a/src/juliapkg/deps.py
+++ b/src/juliapkg/deps.py
@@ -12,6 +12,7 @@ from filelock import FileLock
 from .compat import Compat, Version
 from .find_julia import find_julia, julia_version
 from .install_julia import log, log_script
+from .registry import _find_uuid
 from .state import STATE
 
 logger = logging.getLogger("juliapkg")
@@ -692,7 +693,19 @@ def _add(deps, pkg, uuid=None, **kwargs):
         pkgs[pkg.name] = pkg.depsdict()
     elif isinstance(pkg, str):
         if uuid is None:
-            raise TypeError("uuid is required")
+            uuids = _find_uuid(pkg)
+            if len(uuids) == 0:
+                raise TypeError(
+                    f"Could not find package '{pkg}' in any registry. Are you sure the "
+                    "name is correct? If so, pass the UUID explicitly."
+                )
+            elif len(uuids) == 1:
+                uuid = list(uuids.keys())[0]
+            else:
+                raise TypeError(
+                    f"Multiple UUIDs found for '{pkg}' ({uuids}), pass the UUID "
+                    "explicitly to specify."
+                )
         pkg = PkgSpec(pkg, uuid, **kwargs)
         _add(deps, pkg)
     else:

--- a/src/juliapkg/registry.py
+++ b/src/juliapkg/registry.py
@@ -1,7 +1,8 @@
 import os
 import tarfile
 
-import tomllib
+# we can switch to tomllib when we require python 3.11+
+import tomli
 
 
 def _find_registries():
@@ -16,7 +17,7 @@ def _find_registries():
             if fn.endswith(".toml"):
                 regmetafile = os.path.join(regdir, fn)
                 with open(regmetafile, "rb") as fp:
-                    regmeta = tomllib.load(fp)
+                    regmeta = tomli.load(fp)
                 regmeta["path"] = os.path.join(regdir, regmeta["path"])
                 registries.append(regmeta)
     return registries
@@ -37,10 +38,10 @@ def _load_registry_index(reg):
         raise ValueError(f"registry does not exist: {regpath}")
     if regpath.endswith(".tar.gz"):
         with tarfile.open(regpath) as reg:
-            regidx = tomllib.load(reg.extractfile("Registry.toml"))
+            regidx = tomli.load(reg.extractfile("Registry.toml"))
     elif os.path.isdir(regpath):
         with open(os.path.join(regpath, "Registry.toml"), "rb") as fp:
-            regidx = tomllib.load(fp)
+            regidx = tomli.load(fp)
     else:
         raise ValueError(f"unsupported registry type: {regpath}")
     _REGISTRY_INDEX_CACHE[reghash] = regidx

--- a/src/juliapkg/registry.py
+++ b/src/juliapkg/registry.py
@@ -1,0 +1,61 @@
+import os
+import tarfile
+
+import tomllib
+
+
+def _find_registries():
+    depots = os.environ.get("JULIA_DEPOT_PATH", "").split(os.pathsep)
+    depots.append(os.path.join(os.path.expanduser("~"), ".julia"))
+    registries = []
+    for depot in depots:
+        if not depot:
+            continue
+        regdir = os.path.join(depot, "registries")
+        for fn in os.listdir(regdir):
+            if fn.endswith(".toml"):
+                regmetafile = os.path.join(regdir, fn)
+                with open(regmetafile, "rb") as fp:
+                    regmeta = tomllib.load(fp)
+                regmeta["path"] = os.path.join(regdir, regmeta["path"])
+                registries.append(regmeta)
+    return registries
+
+
+_REGISTRY_INDEX_CACHE = {}
+
+
+def _load_registry_index(reg):
+    # look it up in the cache
+    reghash = reg["git-tree-sha1"]
+    regidx = _REGISTRY_INDEX_CACHE.get(reghash, None)
+    if regidx is not None:
+        return regidx
+    # cache miss, do some parsing
+    regpath = reg["path"]
+    if not os.path.exists(regpath):
+        raise ValueError(f"registry does not exist: {regpath}")
+    if regpath.endswith(".tar.gz"):
+        with tarfile.open(regpath) as reg:
+            regidx = tomllib.load(reg.extractfile("Registry.toml"))
+    elif os.path.isdir(regpath):
+        with open(os.path.join(regpath, "Registry.toml"), "rb") as fp:
+            regidx = tomllib.load(fp)
+    else:
+        raise ValueError(f"unsupported registry type: {regpath}")
+    _REGISTRY_INDEX_CACHE[reghash] = regidx
+    return regidx
+
+
+def _find_uuid(pkgname):
+    uuids = {}
+    for reg in _find_registries():
+        regpath = reg["path"]
+        if not os.path.exists(regpath):
+            continue
+        regidx = _load_registry_index(reg)
+        for uuid, info in regidx["packages"].items():
+            if info["name"] != pkgname:
+                continue
+            uuids.setdefault(uuid, []).append(regpath)
+    return uuids


### PR DESCRIPTION
We do some registry parsing to find the UUID if it is not passed. This makes `juliapkg.add()` a much friendlier function, you don't need to go hunting for the UUID any more.